### PR TITLE
fix: change reference branch to test/agnocast in autoware.repos

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -38,7 +38,7 @@ repositories:
   universe/autoware.universe:
     type: git
     url: git@github.com:tier4/autoware.universe_tmp-agnocast.git
-    version: main
+    version: test/agnocast
   universe/external/tier4_ad_api_adaptor:
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git
@@ -86,7 +86,7 @@ repositories:
   launcher/autoware_launch:
     type: git
     url: git@github.com:tier4/autoware_launch_tmp-agnocast.git
-    version: main
+    version: test/agnocast
   sensor_component/external/sensor_component_description:
     type: git
     url: https://github.com/tier4/sensor_component_description.git
@@ -106,7 +106,7 @@ repositories:
   sensor_kit/sample_sensor_kit_launch:
     type: git
     url: git@github.com:tier4/sample_sensor_kit_launch_tmp-agnocast.git
-    version: main
+    version: test/agnocast
   sensor_kit/external/awsim_sensor_kit_launch:
     type: git
     url: https://github.com/RobotecAI/awsim_sensor_kit_launch.git


### PR DESCRIPTION
Changed referencing branch to test/agnocast in autoware.repos for the following repositories:
-   universe/autoware.universe
-   launcher/autoware_launch
-   sensor_kit/sample_sensor_kit_launch

